### PR TITLE
feat: 토큰 재발급 및 로그아웃 api 연동

### DIFF
--- a/src/api/accounts.ts
+++ b/src/api/accounts.ts
@@ -21,3 +21,8 @@ export const getAccountsProfile = async () => {
 export const putAccountsProfile = async (payload: any) => {
     return await http.PUT(`/accounts/profile`, payload);
 };
+
+// 현재 로그인한 유저의 프로필 정보 반환 (이메일도 표시)
+export const getAccountsReissue = async () => {
+    return await http.GET(`/accounts/reissue`);
+};

--- a/src/api/accounts.ts
+++ b/src/api/accounts.ts
@@ -22,7 +22,12 @@ export const putAccountsProfile = async (payload: any) => {
     return await http.PUT(`/accounts/profile`, payload);
 };
 
-// 현재 로그인한 유저의 프로필 정보 반환 (이메일도 표시)
+// 토큰 재발급 api
 export const getAccountsReissue = async () => {
-    return await http.GET(`/accounts/reissue`);
+    return await http.REISSUE(`/accounts/reissue`);
+};
+
+// 로그아웃 api
+export const getAccountsLogout = async () => {
+    return await http.REISSUE(`/accounts/logout`);
 };

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -39,6 +39,7 @@ export default function LoginPage() {
 
             if (data.accessToken) {
                 localStorage.setItem(CONSTANTS.ACCESS_TOKEN, data.accessToken);
+                localStorage.setItem('f', data.refreshToken);
 
                 const userdata = await getAccountsProfile();
 

--- a/src/components/common/ProfileModal.tsx
+++ b/src/components/common/ProfileModal.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 import { Button } from './Button';
+import { getAccountsLogout } from '@/api/accounts';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { isLoginAtom, userAtom } from '@/store/recoil';
 import defaultImage from '@/assets/icons/icon-default-profile.png';
@@ -30,16 +31,23 @@ export const ProfileModal = ({
         router.push('/mypage/profile');
     };
 
-    const handleLogout = () => {
+    const handleLogout = async () => {
         // TODO - logout api 연동
-        resetUser();
-        localStorage.removeItem(CONSTANTS.ACCESS_TOKEN);
-        setIsLogin(false);
+        try {
+            const data = await getAccountsLogout();
+            if (data) {
+                resetUser();
+                localStorage.removeItem(CONSTANTS.ACCESS_TOKEN);
+                setIsLogin(false);
 
-        setOpen(false);
+                setOpen(false);
 
-        alert('로그아웃 되었습니다.');
-        router.push('/');
+                alert(data.message);
+                router.push('/');
+            }
+        } catch (e) {
+            alert('로그아웃에 실패했습니다.');
+        }
     };
 
     if (!open) {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -3,67 +3,63 @@ import wretch from 'wretch';
 import { CONSTANTS } from '@/constants/common';
 import FormDataAddon from 'wretch/addons/formData';
 import QueryStringAddon from 'wretch/addons/queryString';
-import { getAccountsReissue } from '@/api/accounts';
+import { getAccountsLogout, getAccountsReissue } from '@/api/accounts';
 
 let token = null;
+let refreshToken = null;
 if (typeof window !== 'undefined') {
     // execute only client side
     token = localStorage.getItem(CONSTANTS.ACCESS_TOKEN);
+    refreshToken = localStorage.getItem('f');
 }
 
 const api = wretch(process.env.NEXT_PUBLIC_API_BASE_URL)
     .auth(`${token}`)
     .errorType('json')
+    .resolve((r: any) => r.json() as any)
+    .catcher(500, async (err: any) => {
+        // TODO - response body 확인, refresh token 위치 변경.
+        // 현재 500 에러는 모두 reissue. 정상 작동은 response.details === "JWT EXPIRED" 일때만 reissue 필요.
+        try {
+            const data = await getAccountsReissue();
+
+            if (data) {
+                localStorage.setItem(CONSTANTS.ACCESS_TOKEN, data.accessToken);
+                localStorage.setItem('f', data.refreshToken);
+            }
+        } catch (e) {
+            const data = await getAccountsLogout();
+            localStorage.clear();
+        }
+    });
+
+const reIssueApi = wretch(process.env.NEXT_PUBLIC_API_BASE_URL)
+    .auth(`${refreshToken}`)
+    .errorType('json')
     .resolve((r: any) => r.json() as any);
-
-const reAuthOnTokenExpired = api;
-
-// catcher(
-//     500,
-//     async (error, originalRequest) => {
-//         console.log(error);
-//         const token = await getAccountsReissue();
-
-//         // return originalRequest
-//         //     .auth(`Bearer ${token}`)
-//         //     .fetch() // Replay the request with original method
-//         //     // .unauthorized((err) => {
-//         //     //     throw err;
-//         //     // });
-
-//         // then go ... (see below)
-//     },
-// );
 
 export const http = {
     GET: function get(url: string, query?: any) {
         return query
-            ? reAuthOnTokenExpired
-                  .addon(QueryStringAddon)
-                  .query(query)
-                  .get(url)
-                  .error(0, (err: any) => console.log(err))
-            : reAuthOnTokenExpired
-                  .get(url)
-                  .error(0, (err: any) => console.log(err));
+            ? api.addon(QueryStringAddon).query(query).get(url)
+            : api.get(url);
     },
     POST: function post(url: string, body?: any) {
-        return reAuthOnTokenExpired.url(url).post(body);
+        return api.url(url).post(body);
     },
     PATCH: function patch(url: string, body?: any) {
-        return reAuthOnTokenExpired.url(url).patch(body);
+        return api.url(url).patch(body);
     },
     PUT: function put(url: string, body?: any, params?: any) {
         return params.type === 'record'
-            ? reAuthOnTokenExpired
-                  .addon(FormDataAddon)
-                  .formData(body)
-                  .url(url)
-                  .put()
-            : reAuthOnTokenExpired.url(url).put(body);
+            ? api.addon(FormDataAddon).formData(body).url(url).put()
+            : api.url(url).put(body);
     },
     // delete is a reserved word in JS.
     DELETE: function del(url: string) {
-        return reAuthOnTokenExpired.delete(url);
+        return api.delete(url);
+    },
+    REISSUE: function getReIssue(url: string) {
+        return reIssueApi.get(url);
     },
 };

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -3,6 +3,7 @@ import wretch from 'wretch';
 import { CONSTANTS } from '@/constants/common';
 import FormDataAddon from 'wretch/addons/formData';
 import QueryStringAddon from 'wretch/addons/queryString';
+import { getAccountsReissue } from '@/api/accounts';
 
 let token = null;
 if (typeof window !== 'undefined') {
@@ -15,25 +16,54 @@ const api = wretch(process.env.NEXT_PUBLIC_API_BASE_URL)
     .errorType('json')
     .resolve((r: any) => r.json() as any);
 
+const reAuthOnTokenExpired = api;
+
+// catcher(
+//     500,
+//     async (error, originalRequest) => {
+//         console.log(error);
+//         const token = await getAccountsReissue();
+
+//         // return originalRequest
+//         //     .auth(`Bearer ${token}`)
+//         //     .fetch() // Replay the request with original method
+//         //     // .unauthorized((err) => {
+//         //     //     throw err;
+//         //     // });
+
+//         // then go ... (see below)
+//     },
+// );
+
 export const http = {
     GET: function get(url: string, query?: any) {
         return query
-            ? api.addon(QueryStringAddon).query(query).get(url)
-            : api.get(url);
+            ? reAuthOnTokenExpired
+                  .addon(QueryStringAddon)
+                  .query(query)
+                  .get(url)
+                  .error(0, (err: any) => console.log(err))
+            : reAuthOnTokenExpired
+                  .get(url)
+                  .error(0, (err: any) => console.log(err));
     },
     POST: function post(url: string, body?: any) {
-        return api.url(url).post(body);
+        return reAuthOnTokenExpired.url(url).post(body);
     },
     PATCH: function patch(url: string, body?: any) {
-        return api.url(url).patch(body);
+        return reAuthOnTokenExpired.url(url).patch(body);
     },
     PUT: function put(url: string, body?: any, params?: any) {
         return params.type === 'record'
-            ? api.addon(FormDataAddon).formData(body).url(url).put()
-            : api.url(url).put(body);
+            ? reAuthOnTokenExpired
+                  .addon(FormDataAddon)
+                  .formData(body)
+                  .url(url)
+                  .put()
+            : reAuthOnTokenExpired.url(url).put(body);
     },
     // delete is a reserved word in JS.
     DELETE: function del(url: string) {
-        return api.delete(url);
+        return reAuthOnTokenExpired.delete(url);
     },
 };


### PR DESCRIPTION
<!-- PR 타이틀 양식: [type] 작업 내용 -->

## PR 체크리스트

- [x] 타겟 브랜치를 확인했나요?
- [x] 프리티어, 린트를 실행했나요?

## 작업 내용
- 토큰 reissue api 연동
- logout api 연동

<!-- 작업 사항에 대한 설명을 적어주세요 -->

## 동작 화면 (optional)

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 전달 사항
- TODO - response body 확인 필요
(현재 500 에러는 모두 reissue. 정상 작동은 response.details === "JWT EXPIRED" 일때만 reissue 필요.)
- TODO - refresh token 위치 변경 필요
(현재 작동만을 위해 storage 보관중인데, 해당 위치 어디로 변경할지 논의 필요할 것 같습니다! 🥲)

<!-- 전달 사항이 있다면 적어주세요 -->
