### PR TITLE
feat: SEO 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 // 어플리케이션 공통 레이아웃
 import type { Metadata } from 'next';
-import Favicon from './favicon.ico';
 import { siteConfig } from '@/utils/site';
 
 import Providers from '@/components/adapter/Provider';
@@ -14,14 +13,24 @@ export const metadata: Metadata = {
         default: siteConfig.name,
         template: `%s - ${siteConfig.name}`,
     },
-    icons: [{ rel: 'icon', url: Favicon.src }],
+    icons: {
+        icon: '/favicon.ico',
+    },
     description: siteConfig.description,
+    themeColor: [
+        { media: '(prefers-color-scheme: light)', color: 'white' },
+        { media: '(prefers-color-scheme: dark)', color: 'black' },
+    ],
     keywords: [
         'Tech Interview',
+        'Self Interview Practice',
         'Next.js',
         'Mock Interview',
         'Chat GPT',
+        'Whisper API',
         'QCard',
+        'Tailwind CSS',
+        'Server Components',
     ],
     authors: [
         {
@@ -34,6 +43,21 @@ export const metadata: Metadata = {
         },
     ],
     creator: 'hyosin-Jang',
+    openGraph: {
+        // openGraph는 SNS로 공유될 때 표시되는 내용
+        type: 'website',
+        locale: 'ko_KR', // 사이트 언어 선택 - 기본은 en-US
+        url: siteConfig.url,
+        title: siteConfig.name,
+        description: siteConfig.description, // 사이트 설명
+        siteName: siteConfig.name,
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: siteConfig.name,
+        description: siteConfig.description,
+        creator: 'hyosin-Jang',
+    },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { type Metadata } from 'next';
 import Link from 'next/link';
 import { Footer, Button } from '@/components/common';
 import { DailyQuestionCard } from '@/components/card/DailyQuestionCard';
@@ -11,8 +12,10 @@ import ImgCardDeck3 from '@/assets/images/image-card-deck-3.png';
 import { getQuestionsMain } from '@/api/questions';
 import { IQuestionMain } from '@/types';
 
-export const metadata = {
+export const metadata: Metadata = {
+    metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL!),
     title: 'QCard Home',
+    description: 'Start QCard!',
 };
 
 export default async function Home() {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+// 검색 엔진 크롤러에게 웹 사이트의 url별 접근을 결정하는 파일
+// 책에서 목차로 원하는 페이지를 바로 볼 수 있듯이, 어느 페이지를 방문하고 방문하지 않을지 결정할 수 있음
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+        },
+        sitemap: 'https://qcard.co.kr/sitemap.xml',
+    };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,19 @@
+// sitemap.xml: 검색 엔진 크롤러에게 웹 사이트 구조를 제공
+// 모든 url을 설정하고 페이지별 우선순위를 알려줄 수 있음
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return [
+        { url: 'https://qcard.co.kr' },
+        { url: 'https://qcard.co.kr/interview' },
+        { url: 'https://qcard.co.kr/interview/question' },
+        { url: 'https://qcard.co.kr/category' },
+        { url: 'https://qcard.co.kr/category/question' },
+        { url: 'https://qcard.co.kr/auth/login' },
+        { url: 'https://qcard.co.kr/auth/signup' },
+        { url: 'https://qcard.co.kr/mypage' },
+        { url: 'https://qcard.co.kr/mypage/answer' },
+        { url: 'https://qcard.co.kr/mypage/question' },
+        { url: 'https://qcard.co.kr/mypage/profile' },
+    ];
+}


### PR DESCRIPTION
<!-- PR 타이틀 양식: [type] 작업 내용 -->

## PR 체크리스트

- [x] 타겟 브랜치를 확인했나요?
- [x] 프리티어, 린트를 실행했나요?

## 작업 내용

- Rootlayout에 opengraph, twitter를 포함한 Metadata를 설정했습니다.
- Home페이지에 page별 metadata를 설정했고, 인터뷰쪽은 서버 컴포넌트라 작업하지 않았습니다.
- app/robots.ts에 루트 페이지를 허용된 페이지로 추가했고, app/sitemap.ts에 url별 우선순위 추가했습니다.
- 인터뷰쪽에 쿼리스트링이 사용되긴 하지만, 각 페이지별로 콘텐츠가 다르므로 canonical 태그는 적용하지 않았습니다.

## 동작 화면 (optional)

<img width="350" alt="image" src="https://github.com/Q-CARD/QCard-client/assets/71035113/bb620fc5-94fd-4a00-b59b-332c58e6e43e">


## 전달 사항
closes #87 
